### PR TITLE
New updates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,6 +94,7 @@ jobs:
         with:
           command: sdist
           args: --out dist
+          working-directory: ./bindings
       - name: Upload sdist
         uses: actions/upload-artifact@v3
         with:
@@ -103,6 +104,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [linux, windows, macos, sdist]
     steps:
@@ -112,8 +116,6 @@ jobs:
           path: ./bindings/dist
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
-          args: --non-interactive --skip-existing *
+          args: --non-interactive --skip-existing ./bindings/dist/*

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,13 +6,8 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
-      - master
-    tags:
-      - '*'
-  pull_request:
+  release:
+    types: [created]
   workflow_dispatch:
 
 permissions:
@@ -23,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
+        target: [x86_64, x86, aarch64]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -36,11 +31,12 @@ jobs:
           args: --release --out dist --find-interpreter
           sccache: 'true'
           manylinux: auto
+          working-directory: ./bindings
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: dist
+          path: ./bindings/dist
 
   windows:
     runs-on: windows-latest
@@ -59,11 +55,12 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter
           sccache: 'true'
+          working-directory: ./bindings
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: dist
+          path: ./bindings/dist
 
   macos:
     runs-on: macos-latest
@@ -81,11 +78,12 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter
           sccache: 'true'
+          working-directory: ./bindings
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: dist
+          path: ./bindings/dist
 
   sdist:
     runs-on: ubuntu-latest
@@ -100,7 +98,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: dist
+          path: ./bindings/dist
 
   release:
     name: Release
@@ -111,6 +109,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: wheels
+          path: ./bindings/dist
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "rust_gc_count"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64-url",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_gc_count"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Andy Yates"]
 description = "GC and sequence utilities"

--- a/NOTICE
+++ b/NOTICE
@@ -3,3 +3,4 @@ Copyright [2023] EMBL-European Bioinformatics Institute
 
 This product includes software developed at:
 - EMBL-European Bioinformatics Institute
+- University of Virginia, Center for Public Health Genomics

--- a/bindings/Cargo.lock
+++ b/bindings/Cargo.lock
@@ -209,15 +209,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gc_count"
-version = "0.1.0"
-dependencies = [
- "pyo3",
- "rust_gc_count",
- "seq_io",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +406,15 @@ dependencies = [
  "md-5",
  "seq_io",
  "sha2",
+]
+
+[[package]]
+name = "rust_gc_count_py"
+version = "0.1.0"
+dependencies = [
+ "pyo3",
+ "rust_gc_count",
+ "seq_io",
 ]
 
 [[package]]

--- a/bindings/Cargo.lock
+++ b/bindings/Cargo.lock
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "rust_gc_count"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64-url",
  "clap",

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "gc_count"
+name = "rust_gc_count_py"
 version = "0.1.0"
 edition = "2021"
 

--- a/bindings/gc_count.pyi
+++ b/bindings/gc_count.pyi
@@ -1,0 +1,16 @@
+from typing import List
+
+class ChecksumResult:
+    def __init__(self, id: str, length: int, sha512: str, md5: str):
+        self.id = id
+        self.length = length
+        self.sha512 = sha512
+        self.md5 = md5
+
+    def __repr__(self):
+        return f"ChecksumResult(id={self.id}, length={self.length}, sha512={self.sha512}, md5={self.md5})"
+
+    def __str__(self):
+        return f"ChecksumResult(id={self.id}, length={self.length}, sha512={self.sha512}, md5={self.md5})"
+
+def checksum(file: str, verbose: bool) -> List[ChecksumResult]: ...

--- a/bindings/gc_count.pyi
+++ b/bindings/gc_count.pyi
@@ -26,3 +26,32 @@ def checksum(file: str, verbose: bool) -> List[ChecksumResult]:
     :param file: The file to checksum
     :param verbose: Whether to print out the progress
     """
+
+def write_gc_count_to_file(
+    input: str,
+    output: str,
+    compression_level: int,
+    window_size: int,
+    omit_tail: bool,
+    chrom_sizes_path: str,
+    write_chrom_sizes: bool,
+    verbose: bool,
+) -> None:
+    """
+    Calculate the GC content and write it to a file. The file will be a
+    tab-separated file with the following columns:
+    
+    Chromosome name
+    Start position
+    End position
+    GC content
+
+    :param input: The input file to calculate the GC content from
+    :param output: The output file to write the GC content to
+    :param compression_level: The compression level to use for the output file
+    :param window_size: The window size to use for calculating the GC content
+    :param omit_tail: Whether to omit the tail of the sequence
+    :param chrom_sizes_path: The path to the chromosome sizes file
+    :param write_chrom_sizes: Whether to write the chromosome sizes to the output file
+    :param verbose: Whether to print out the progress
+    """       

--- a/bindings/gc_count.pyi
+++ b/bindings/gc_count.pyi
@@ -13,4 +13,16 @@ class ChecksumResult:
     def __str__(self):
         return f"ChecksumResult(id={self.id}, length={self.length}, sha512={self.sha512}, md5={self.md5})"
 
-def checksum(file: str, verbose: bool) -> List[ChecksumResult]: ...
+def checksum(file: str, verbose: bool) -> List[ChecksumResult]:
+    """
+    Calculate the sequence lengths and checksums from a fasta file. It will
+    produce a list of ChecksumResult objects, each containing the following
+    
+    Sequence ID as it appears in the FASTA file
+    Sequence length
+    Refget ga4gh identifier (SQ.sha512t24u)
+    MD5 checksum hex encoded
+
+    :param file: The file to checksum
+    :param verbose: Whether to print out the progress
+    """

--- a/bindings/src/checksumseq.rs
+++ b/bindings/src/checksumseq.rs
@@ -14,14 +14,9 @@ pub fn checksum(file: String, verbose: Option<bool>) -> Vec<PyChecksumResult> {
 
     while let Some(record) = reader.next() {
         let record = record.unwrap();
-        let (id, length, sha512, md5) = process_sequence(record, verbose);
-        
-        results.push(PyChecksumResult {
-            id,
-            length,
-            sha512,
-            md5
-        });
+        let result = process_sequence(record, verbose);
+
+        results.push(PyChecksumResult::from(result));
     }
 
     results

--- a/bindings/src/gc_count_utils.rs
+++ b/bindings/src/gc_count_utils.rs
@@ -1,0 +1,21 @@
+use pyo3::prelude::*;
+use std::path::PathBuf;
+
+#[pyfunction]
+pub fn write_gc_count_to_file(
+    input: String,
+    output: String,
+    compression_level: u32,
+    window_size: i32,
+    omit_tail: bool,
+    chrom_sizes_path: String,
+    write_chrom_sizes: bool,
+    verbose: bool,
+) {
+
+    let input = PathBuf::from(input);
+    let output = PathBuf::from(output);
+    let chrom_sizes_path = PathBuf::from(chrom_sizes_path);
+
+    rust_gc_count::gc_count::write_gc_to_file(input, output, compression_level, window_size, omit_tail, chrom_sizes_path, write_chrom_sizes, verbose)
+}

--- a/bindings/src/lib.rs
+++ b/bindings/src/lib.rs
@@ -1,13 +1,16 @@
 use pyo3::prelude::*;
 
+pub mod gc_count_utils;
 pub mod checksumseq;
 pub mod models;
 
 use crate::checksumseq::checksum;
+use crate::gc_count_utils::write_gc_count_to_file;
 
 /// A Python module implemented in Rust.
 #[pymodule]
 fn gc_count(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(checksum, m)?)?;
+    m.add_function(wrap_pyfunction!(write_gc_count_to_file, m)?)?;
     Ok(())
 }

--- a/bindings/src/models.rs
+++ b/bindings/src/models.rs
@@ -14,6 +14,13 @@ pub struct PyChecksumResult {
     pub md5: String
 }
 
+#[pymethods]
+impl PyChecksumResult {
+    fn __repr__(&self) -> String {
+        format!("<ChecksumResult for {}>", self.id)
+    }
+}
+
 impl From<ChecksumResult> for PyChecksumResult {
     fn from(value: ChecksumResult) -> Self {
         PyChecksumResult {

--- a/bindings/src/models.rs
+++ b/bindings/src/models.rs
@@ -1,4 +1,5 @@
 use pyo3::prelude::*;
+use rust_gc_count::checksum::ChecksumResult;
 
 #[pyclass]
 #[pyo3(name="ChecksumResult")]
@@ -11,4 +12,15 @@ pub struct PyChecksumResult {
     pub sha512: String,
     #[pyo3(get,set)]
     pub md5: String
+}
+
+impl From<ChecksumResult> for PyChecksumResult {
+    fn from(value: ChecksumResult) -> Self {
+        PyChecksumResult {
+            id: value.id,
+            length: value.length,
+            sha512: value.sha512,
+            md5: value.md5
+        }
+    }
 }

--- a/src/checksumseq.rs
+++ b/src/checksumseq.rs
@@ -59,10 +59,13 @@ fn main() {
     while let Some(record) = reader.next() {
         let record = record.expect("Error reading record");
         let result = process_sequence(record, args.verbose);
-        let line = format!(
-            "{0:#}\t{1:#}\tSQ.{2:#}\t{3:#}\n",
-            result.0, result.1, result.2, result.3
-        );
+
+        let id = result.id;
+        let length = result.length;
+        let sha512 = result.sha512;
+        let md5 = result.md5;
+
+        let line = format!("{0:#}\t{1:#}\tSQ.{2:#}\t{3:#}\n", id, length, sha512, md5);
         writer
             .write_all(line.as_bytes())
             .expect("Could not write to file");
@@ -89,9 +92,9 @@ acgT\n
     while let Some(record) = reader.next() {
         let record = record.expect("Error reading record");
         let result = process_sequence(record, false);
-        assert_eq!(result.0, "id");
-        assert_eq!(result.1, 4);
-        assert_eq!(result.2, "aKF498dAxcJAqme6QYQ7EZ07-fiw8Kw2");
-        assert_eq!(result.3, "f1f8f4bf413b16ad135722aa4591043e");
+        assert_eq!(result.id, "id");
+        assert_eq!(result.length, 4);
+        assert_eq!(result.sha512, "aKF498dAxcJAqme6QYQ7EZ07-fiw8Kw2");
+        assert_eq!(result.md5, "f1f8f4bf413b16ad135722aa4591043e");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,13 @@
-use sha2::Sha512;
+use flate2::read::MultiGzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use md5::{Digest, Md5};
-use seq_io::fasta::{Record, RefRecord};
+use seq_io::fasta::{Reader, Record, RefRecord};
+use sha2::Sha512;
+use std::fs::File;
+use std::io::prelude::{Read, Write};
+
+use std::io::BufWriter;
 
 pub mod checksum {
 
@@ -21,7 +28,123 @@ pub mod checksum {
         }
         let sha512 = base64_url::encode(&sha512_hasher_box.as_mut().finalize_reset()[0..24]);
         let md5 = format!("{:x}", md5_hasher_box.as_mut().finalize_reset());
-        
+
         (id.to_string(), length, sha512, md5)
+    }
+}
+
+pub mod gc_count {
+
+    use std::path::PathBuf;
+
+    use super::*;
+
+    pub fn write_gc(gc_count: i32, window_size: i32, iter_count: i32, writer: &mut impl Write) {
+        let gc = (gc_count as f32 / window_size as f32) * 100_f32;
+        let start_location = ((iter_count - 1) * window_size) + 1;
+        writer
+            .write_all(format!("{}\t{}\n", start_location, gc as i32).as_bytes())
+            .expect("Write failed");
+    }
+
+    pub fn write_gc_to_file(
+        input: PathBuf,
+        output: PathBuf,
+        compression_level: u32,
+        window_size: i32,
+        omit_tail: bool,
+        chrom_sizes_path: PathBuf,
+        write_chrom_sizes: bool,
+        verbose: bool,
+    ) {
+        let read = if input.extension().unwrap() == "gz" {
+            Box::new(MultiGzDecoder::new(File::open(input).unwrap())) as Box<dyn Read>
+        } else {
+            Box::new(File::open(input).unwrap()) as Box<dyn Read>
+        };
+        let mut reader = Reader::new(read);
+        let write: Box<dyn Write> = if output.extension().unwrap() == "gz" {
+            Box::new(GzEncoder::new(
+                File::create(output).expect("creation failed"),
+                Compression::new(compression_level),
+            )) as Box<dyn Write>
+        } else {
+            Box::new(File::create(output).expect("creation failed")) as Box<dyn Write>
+        };
+        let mut writer = BufWriter::new(write);
+
+        if verbose && write_chrom_sizes {
+            eprintln!("==> Will write chrom.sizes file to {:?}", chrom_sizes_path);
+        }
+        let mut chrom_sizes_writer = if write_chrom_sizes {
+            let tmp_writer =
+                BufWriter::new(File::create(chrom_sizes_path).expect("Creation failed"));
+            Some(tmp_writer)
+        } else {
+            None
+        };
+
+        writer
+            .write_all("track type=wiggle_0\n".as_bytes())
+            .expect("Write failed");
+        let mut n = 0;
+        while let Some(record) = reader.next() {
+            let record = record.expect("Error reading record");
+            let id = record.id().unwrap();
+            if verbose {
+                eprint!("==> Processing region {:?} ... ", id);
+            }
+            // variabletep is used versus fixedStep because there are differences in the
+            // resulting BigWigs. Using variableStep keeps this inline with UCSC
+            // gc BigWig files
+            writer
+                .write_all(format!("variableStep chrom={0} span={1}\n", id, window_size).as_bytes())
+                .expect("Write failed");
+            let mut length = 0;
+            let mut gc_count = 0;
+            let mut window_count = 0_i32;
+            let mut iter_count = 0_i32;
+            for s in record.seq_lines() {
+                for c in s.iter() {
+                    if *c == b'C' || *c == b'G' {
+                        gc_count += 1;
+                    }
+                    window_count += 1;
+                    if window_count == window_size {
+                        iter_count += 1;
+                        write_gc(gc_count, window_size, iter_count, &mut writer);
+                        gc_count = 0;
+                        window_count = 0;
+                    }
+                }
+                length += s.len();
+            }
+            if !omit_tail && window_count > 0 {
+                write_gc(gc_count, window_count, iter_count, &mut writer);
+            }
+
+            if chrom_sizes_writer.is_some() {
+                chrom_sizes_writer
+                    .as_mut()
+                    .unwrap()
+                    .write_all(format!("{0}\t{1}\n", record.id().unwrap(), length).as_bytes())
+                    .expect("Write failed");
+            }
+            n += 1;
+            if verbose {
+                eprintln!("done");
+            }
+        }
+        writer.flush().expect("Could not close wig output file");
+        if chrom_sizes_writer.is_some() {
+            chrom_sizes_writer
+                .as_mut()
+                .unwrap()
+                .flush()
+                .expect("Could not close chrom sizes stream");
+        }
+        if verbose {
+            eprintln!("==> Found and processed {} regions.", n);
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod checksum {
 
     use super::*;
 
-    pub fn process_sequence(record: RefRecord, verbose: bool) -> (String, usize, String, String) {
+    pub fn process_sequence(record: RefRecord, verbose: bool) -> ChecksumResult {
         let mut md5_hasher_box = Box::new(Md5::new());
         let mut sha512_hasher_box = Box::new(Sha512::new());
         let id = record.id().unwrap();
@@ -29,7 +29,19 @@ pub mod checksum {
         let sha512 = base64_url::encode(&sha512_hasher_box.as_mut().finalize_reset()[0..24]);
         let md5 = format!("{:x}", md5_hasher_box.as_mut().finalize_reset());
 
-        (id.to_string(), length, sha512, md5)
+        ChecksumResult {
+            id: id.to_string(),
+            length,
+            sha512,
+            md5,
+        }
+    }
+
+    pub struct ChecksumResult {
+        pub id: String,
+        pub length: usize,
+        pub sha512: String,
+        pub md5: String,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,12 @@
 use clap::Parser;
-use flate2::read::MultiGzDecoder;
-use flate2::write::GzEncoder;
-use flate2::Compression;
-use seq_io::fasta::{Reader, Record};
-use std::fs::File;
-use std::io::prelude::{Read, Write};
-use std::io::BufWriter;
+use rust_gc_count::gc_count::write_gc_to_file;
 
 /// Parse a FASTA file and calculate GC based on the specified window into a wig file
 #[derive(Parser)]
 #[command(
-    author, 
+    author = "Andrew Yates",
     name = "gccount", 
-    version, 
+    version = env!("CARGO_PKG_VERSION"), 
     about = "Calculate GC and write into a wiggle file", 
     long_about = None
 )]
@@ -46,113 +40,30 @@ struct Cli {
 fn main() {
     let args = Cli::parse();
 
+    let input = args.input;
+    let output = args.output;
+    let compression_level = args.compression_level;
+    let window_size = args.window;
+    let omit_tail = args.omit_tail;
+    let chrom_sizes_path = args.chrom_sizes_path;
+    let write_chrom_sizes = args.write_chrom_sizes;
+    let verbose = args.verbose;
+
     if args.verbose {
         eprintln!(
             "==> Processing FASTA file {:?} and writing to {:?}",
-            args.input, args.output
+            input, output
         );
     }
 
-    let read = if args.input.extension().unwrap() == "gz" {
-        Box::new(MultiGzDecoder::new(File::open(args.input).unwrap())) as Box<dyn Read>
-    } else {
-        Box::new(File::open(args.input).unwrap()) as Box<dyn Read>
-    };
-    let mut reader = Reader::new(read);
-    let write: Box<dyn Write> = if args.output.extension().unwrap() == "gz" {
-        Box::new(GzEncoder::new(
-            File::create(args.output).expect("creation failed"),
-            Compression::new(args.compression_level),
-        )) as Box<dyn Write>
-    } else {
-        Box::new(File::create(args.output).expect("creation failed")) as Box<dyn Write>
-    };
-    let mut writer = BufWriter::new(write);
-
-    if args.verbose && args.write_chrom_sizes {
-        eprintln!(
-            "==> Will write chrom.sizes file to {:?}",
-            args.chrom_sizes_path
-        );
-    }
-    let mut chrom_sizes_writer = if args.write_chrom_sizes {
-        let tmp_writer =
-            BufWriter::new(File::create(args.chrom_sizes_path).expect("Creation failed"));
-        Some(tmp_writer)
-    } else {
-        None
-    };
-
-    let window_size: i32 = args.window;
-
-    writer
-        .write_all("track type=wiggle_0\n".as_bytes())
-        .expect("Write failed");
-    let mut n = 0;
-    while let Some(record) = reader.next() {
-        let record = record.expect("Error reading record");
-        let id = record.id().unwrap();
-        if args.verbose {
-            eprint!("==> Processing region {:?} ... ", id);
-        }
-        // variabletep is used versus fixedStep because there are differences in the
-        // resulting BigWigs. Using variableStep keeps this inline with UCSC
-        // gc BigWig files
-        writer
-            .write_all(format!("variableStep chrom={0} span={1}\n", id, window_size).as_bytes())
-            .expect("Write failed");
-        let mut length = 0;
-        let mut gc_count = 0;
-        let mut window_count = 0_i32;
-        let mut iter_count = 0_i32;
-        for s in record.seq_lines() {
-            for c in s.iter() {
-                if *c == b'C' || *c == b'G' {
-                    gc_count += 1;
-                }
-                window_count += 1;
-                if window_count == window_size {
-                    iter_count += 1;
-                    write_gc(gc_count, window_size, iter_count, &mut writer);
-                    gc_count = 0;
-                    window_count = 0;
-                }
-            }
-            length += s.len();
-        }
-        if !args.omit_tail && window_count > 0 {
-            write_gc(gc_count, window_count, iter_count, &mut writer);
-        }
-
-        if chrom_sizes_writer.is_some() {
-            chrom_sizes_writer
-                .as_mut()
-                .unwrap()
-                .write_all(format!("{0}\t{1}\n", record.id().unwrap(), length).as_bytes())
-                .expect("Write failed");
-        }
-        n += 1;
-        if args.verbose {
-            eprintln!("done");
-        }
-    }
-    writer.flush().expect("Could not close wig output file");
-    if chrom_sizes_writer.is_some() {
-        chrom_sizes_writer
-            .as_mut()
-            .unwrap()
-            .flush()
-            .expect("Could not close chrom sizes stream");
-    }
-    if args.verbose {
-        eprintln!("==> Found and processed {} regions.", n);
-    }
-}
-
-fn write_gc(gc_count: i32, window_size: i32, iter_count: i32, writer: &mut impl Write) {
-    let gc = (gc_count as f32 / window_size as f32) * 100_f32;
-    let start_location = ((iter_count - 1) * window_size) + 1;
-    writer
-        .write_all(format!("{}\t{}\n", start_location, gc as i32).as_bytes())
-        .expect("Write failed");
+    write_gc_to_file(
+        input,
+        output,
+        compression_level,
+        window_size,
+        omit_tail,
+        chrom_sizes_path,
+        write_chrom_sizes,
+        verbose,
+    );
 }


### PR DESCRIPTION
Hey!

Small iteration on top of what I already had going..

### For the core rust package:
As mentioned before, I kept the two binary crates and added a library crate. The library crate has two modules: 1) `checksum` and 2) `gc_count`. All the actual *logic* for computing checksums and gc-count lives in these modules in the library crate. The binary crates now import the necessary functions and add some "glue" (the CLI you made) to make it work via the command line. This approach is nice because it's modular and lets other things import that logic and reuse it. For example...

### The python bindings
These are their own self-contained crate inside the `bindings` folder. They leverage the library crate mentioned before and just import that code and then add more "glue" to make it all interface nicely with Python. You can see in the `Cargo.toml` I'm adding `rust_gc_count` as a dependency and just pointing one directory up...
```toml
rust_gc_count = { path = "../" }
```

Finally, I added python bindings for writing gc counts to a wiggle file like you had before in the CLI, but now you can do it from within python. I also added some type hinting and doc strings using [stub files](https://mypy.readthedocs.io/en/stable/stubs.html) to make it more user-friendly :)

<div align="center">
<img width="500" alt="image" src="https://github.com/andrewyatz/rust-gc-count/assets/41063083/60817a54-ba94-4e1d-b3ea-b989d1d36f44">
</div>

Let me know if you have questions or suggestions for improvement!